### PR TITLE
Add new control panel to host top banner #21

### DIFF
--- a/src/plonetheme/eeq/browser/banner.py
+++ b/src/plonetheme/eeq/browser/banner.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from zope.component import getUtility
 from plone.app.layout.viewlets import common as base
 from plone.registry.interfaces import IRegistry
@@ -11,10 +11,10 @@ class AboveHeaderBanner(base.ViewletBase):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(ISettings, False)
 
-        today = date.today()
-        if settings.top_banner_publication_date and today < settings.top_banner_publication_date:
+        now = datetime.now()
+        if settings.top_banner_publication_date and now < settings.top_banner_publication_date:
             return ""
-        if settings.top_banner_retire_date and today >= settings.top_banner_retire_date:
+        if settings.top_banner_retire_date and now >= settings.top_banner_retire_date:
             return ""
         if not settings.top_banner_body:
             return ""

--- a/src/plonetheme/eeq/browser/banner.py
+++ b/src/plonetheme/eeq/browser/banner.py
@@ -1,0 +1,22 @@
+from datetime import date
+from zope.component import getUtility
+from plone.app.layout.viewlets import common as base
+from plone.registry.interfaces import IRegistry
+from plone import api
+from plonetheme.eeq.interfaces import ISettings
+
+
+class AboveHeaderBanner(base.ViewletBase):
+    def render(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISettings, False)
+
+        today = date.today()
+        if settings.top_banner_publication_date and today < settings.top_banner_publication_date:
+            return ""
+        if settings.top_banner_retire_date and today >= settings.top_banner_retire_date:
+            return ""
+        if not settings.top_banner_body:
+            return ""
+        url = api.portal.get().absolute_url()
+        return '<div id="AboveHeaderBanner">' + settings.top_banner_body.replace("${portal_url}", url) + "</div>"

--- a/src/plonetheme/eeq/browser/configure.zcml
+++ b/src/plonetheme/eeq/browser/configure.zcml
@@ -18,4 +18,20 @@
       directory="static"
       />
 
+  <browser:page
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      name="psu-equity-settings"
+      class=".controlpanel.SettingsControlPanelView"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:viewlet
+      name="plonetheme.eeq.above-header-banner"
+      for="*"
+      manager="plone.app.layout.viewlets.interfaces.IPortalTop"
+      layer="plonetheme.eeq.interfaces.IPlonethemeEeqLayer"
+      class=".banner.AboveHeaderBanner"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/src/plonetheme/eeq/browser/controlpanel.py
+++ b/src/plonetheme/eeq/browser/controlpanel.py
@@ -1,0 +1,5 @@
+from plone.app.registry.browser.controlpanel import RegistryEditForm
+from plonetheme.eeq.interfaces import ISettings
+
+class SettingsControlPanelView(RegistryEditForm):
+    schema = ISettings

--- a/src/plonetheme/eeq/configure.zcml
+++ b/src/plonetheme/eeq/configure.zcml
@@ -113,4 +113,11 @@
       import_steps="typeinfo"
       />
 
+  <genericsetup:upgradeDepends
+      source="1005"
+      destination="1006"
+      title="Add settings control panel for top banner config"
+      profile="plonetheme.eeq:default"
+      import_steps="controlpanel plone.app.registry viewlets"
+      />
 </configure>

--- a/src/plonetheme/eeq/interfaces.py
+++ b/src/plonetheme/eeq/interfaces.py
@@ -34,12 +34,12 @@ class ISettings(model.Schema):
             </div>
         """,
     )
-    top_banner_publication_date = schema.Date(
+    top_banner_publication_date = schema.Datetime(
         title="Only publish after this date",
         description="This date is the first day the banner will be shown",
         required=False
     )
-    top_banner_retire_date = schema.Date(
+    top_banner_retire_date = schema.Datetime(
         title="Do not publish after this date",
         description="This date is the first day the banner will be hidden",
         required=False

--- a/src/plonetheme/eeq/interfaces.py
+++ b/src/plonetheme/eeq/interfaces.py
@@ -2,7 +2,45 @@
 """Module where all interfaces, events and exceptions live."""
 
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from plone.supermodel import model
+from plone.app.textfield import RichText
+from zope import schema
 
 
 class IPlonethemeEeqLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
+
+class ISettings(model.Schema):
+    top_banner_body = schema.Text(
+        title="Banner to display at the top of the site",
+        description="You can use the placeholder <pre>${portal_url}</pre> to refer to assets",
+        default="""
+            <div class="container-fluid constrain-width banner">
+                <div class="row py-3 banner-content">
+                    <div class="col-xs-12 col-md-10 col-lg-8 offset-md-1 offset-lg-2">
+                        <img alt="Important message follows"
+                            class="float-left mr-3"
+                            src="${portal_url}/++theme++psu-educational-equity/images/alert-icon-dark.png" />
+                        <p>
+                            <strong>Coronavirus updates:</strong>
+                            To keep up with the latest from Penn State about the global
+                            coronavirus outbreak, visit
+                            <a href="https://sites.psu.edu/virusinfo/">
+                                <b>the Coronavirus information website</b>
+                            </a>.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        """,
+    )
+    top_banner_publication_date = schema.Date(
+        title="Only publish after this date",
+        description="This date is the first day the banner will be shown",
+        required=False
+    )
+    top_banner_retire_date = schema.Date(
+        title="Do not publish after this date",
+        description="This date is the first day the banner will be hidden",
+        required=False
+    )

--- a/src/plonetheme/eeq/profiles/default/controlpanel.xml
+++ b/src/plonetheme/eeq/profiles/default/controlpanel.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel">
+    <configlet
+        title="Equity site settings"
+        action_id="psu.equity.settings"
+        appId="psu.equity"
+        category="Products"
+        condition_expr=""
+        url_expr="string:${portal_url}/@@psu-equity-settings"
+        icon_expr=""
+        visible="True">
+    <permission>cmf.ManagePortal</permission>
+    </configlet>
+</object>

--- a/src/plonetheme/eeq/profiles/default/metadata.xml
+++ b/src/plonetheme/eeq/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <metadata>
-  <version>1005</version>
+  <version>1006</version>
   <dependencies>
     <dependency>profile-plone.app.theming:default</dependency>
     <dependency>profile-jazkarta.tesserae:default</dependency>

--- a/src/plonetheme/eeq/profiles/default/registry/main.xml
+++ b/src/plonetheme/eeq/profiles/default/registry/main.xml
@@ -7,4 +7,5 @@
   <records prefix="plone" interface="Products.CMFPlone.interfaces.ILinkSchema">
     <value key="mark_special_links">False</value>
   </records>
+  <records interface="plonetheme.eeq.interfaces.ISettings" />
 </registry>

--- a/src/plonetheme/eeq/profiles/default/viewlets.xml
+++ b/src/plonetheme/eeq/profiles/default/viewlets.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object>
+  <order manager="plone.portaltop" skinname="*">
+    <viewlet name="plonetheme.eeq.above-header-banner" insert-before="*"/>
+  </order>
+</object>

--- a/src/plonetheme/eeq/theme/index.html
+++ b/src/plonetheme/eeq/theme/index.html
@@ -38,20 +38,7 @@
         data-base-url="https://beta.equity.psu.edu/web"
         >
     <div id="portal-toolbar"></div>
-    <div class="container-fluid constrain-width banner">
-      <div class="row py-3 banner-content">
-        <div class="col-xs-12 col-md-10 col-lg-8 offset-md-1 offset-lg-2">
-          <img alt="Important message follows"
-               class="float-left mr-3"
-               src="images/alert-icon-dark.png" />
-          <p>
-            <strong>Coronavirus updates:</strong>
-            To keep up with the latest from Penn State about the global
-            coronavirus outbreak, visit
-            <a href="https://sites.psu.edu/virusinfo/"><b>the Coronavirus information website</b></a>.
-          </p>
-        </div>
-      </div>
+    <div class="container-fluid constrain-width banner" id="above-header-banner">
     </div>
 
     <nav class="navbar navbar-expand-lg navbar-dark bg-header navbar-header">

--- a/src/plonetheme/eeq/theme/rules.xml
+++ b/src/plonetheme/eeq/theme/rules.xml
@@ -170,6 +170,8 @@
       css:theme-children="html body"
       content="//footer[@id='portal-footer-wrapper']/*[not(@class='row')]"
       />
+  <!-- Top banner viewlet -->
+  <replace css:theme="#above-header-banner" css:content-children="#AboveHeaderBanner" />
 
   <!-- toolbar -->
   <replace css:theme="#portal-toolbar" css:content="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />


### PR DESCRIPTION
See #21 

The control panel has three fields: start date, end date and banner contents.

The banner contents are editable as HTML in a textarea. The string `${portal_url}` can be used in the banner content and it will be replaced when rendered.

If start or end dates are provided they will be honoured.

There is no check that the start date is before the end date. In case dates are swapped the banner will never be shown. 