### PR TITLE
Alert tile date range functionality

### DIFF
--- a/src/plonetheme/eeq/browser/tiles.py
+++ b/src/plonetheme/eeq/browser/tiles.py
@@ -13,6 +13,7 @@ from plone.supermodel import model
 from plone import api
 from zExceptions import Unauthorized
 from zope import schema
+from datetime import datetime
 
 
 class IAlertTile(model.Schema):
@@ -39,6 +40,25 @@ class IAlertTile(model.Schema):
         title=_(u'Specify external url to link to (optional)'),
         description="Please include full url with 'http/https' prefix",
         required=False,
+    )
+
+    use_date_range = schema.Bool(
+        title=_(u'Use date range'),
+        description="Optionally, restrict display date range by providing publication and expiration dates",
+        default=False,
+        required=False
+    )
+
+    publication_date = schema.Datetime(
+        description="Display tile from this date",
+        title=_(u'Publication Date'),
+        required=False
+    )
+
+    expiration_date = schema.Datetime(
+        description="Display tile until this date",
+        title=_(u'Expiration Date'),
+        required=False
     )
 
     # can add more alert styles here 1/3
@@ -98,5 +118,18 @@ class AlertTile(Tile):
 
         style_table = {'primary' : 'alert-primary', 
                        'warning' : 'alert-danger'}
+
+        # expiration check
+        if self.data.get('use_date_range'):
+
+            pub_date = self.data.get('publication_date')
+            exp_date = self.data.get('expiration_date')
+            now = datetime.now()
+            if pub_date:
+                if now < datetime.strptime(pub_date, '%Y-%m-%dT%H:%M:%S'):
+                    return 'alert ' + style_table[choice] + ' in-active'
+            if exp_date:
+                if now >= datetime.strptime(exp_date, '%Y-%m-%dT%H:%M:%S'):
+                    return 'alert ' + style_table[choice] + ' in-active'
 
         return 'alert ' + style_table[choice]

--- a/src/plonetheme/eeq/browser/tiles.py
+++ b/src/plonetheme/eeq/browser/tiles.py
@@ -1,12 +1,14 @@
 from plonetheme.eeq import _
+from plonetheme.eeq.overrides import TileDatetime
 from jazkarta.tesserae.utils import uuidToObject
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.vocabularies.catalog import CatalogSource
+from plone.autoform import directives as form
 try:
     from plone.app.widgets.dx import RelatedItemsWidget
-    from plone.autoform import directives as form
 except ImportError:
     RelatedItemsWidget = None
+from plone.app.z3cform.widget import DatetimeWidget
 from plone.memoize.view import memoize
 from plone.tiles import Tile
 from plone.supermodel import model
@@ -49,17 +51,20 @@ class IAlertTile(model.Schema):
         required=False
     )
 
-    publication_date = schema.Datetime(
+    publication_date = TileDatetime(
         description="Display tile from this date",
         title=_(u'Publication Date'),
         required=False
     )
 
-    expiration_date = schema.Datetime(
+    expiration_date = TileDatetime(
         description="Display tile until this date",
         title=_(u'Expiration Date'),
         required=False
     )
+
+    form.widget('publication_date', DatetimeWidget)
+    form.widget('expiration_date', DatetimeWidget)
 
     # can add more alert styles here 1/3
     style = schema.Choice(

--- a/src/plonetheme/eeq/configure.zcml
+++ b/src/plonetheme/eeq/configure.zcml
@@ -129,4 +129,6 @@
       import_steps="plone.app.registry"
       />
 
+  <adapter factory=".overrides.TileDatetimeWidgetConverter" />
+
 </configure>

--- a/src/plonetheme/eeq/overrides.py
+++ b/src/plonetheme/eeq/overrides.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from zope.component import adapter
+from zope.interface import implementer
+from zope.schema._bootstrapfields import Field
+from zope.schema._bootstrapfields import Orderable
+from zope.schema.interfaces import IDatetime
+from plone.app.z3cform.interfaces import IDatetimeWidget
+from plone.app.z3cform.converters import DatetimeWidgetConverter
+
+
+class ITileDatetime(IDatetime):
+    """Datetime field to render in a tile"""
+
+
+@implementer(ITileDatetime)
+class TileDatetime(Orderable, Field):
+    __doc__ = ITileDatetime.__doc__
+    _type = datetime
+
+    def __init__(self, *args, **kw):
+        super(TileDatetime, self).__init__(*args, **kw)
+
+
+@adapter(ITileDatetime, IDatetimeWidget)
+class TileDatetimeWidgetConverter(DatetimeWidgetConverter):
+    """Data converter for datetime fields in tiles.
+
+    Since `plone.app.blocks.layoutbehavior.LayoutAwareTileDataStorage.__setitem__`
+    invokes `json_compatible` before storing its data we need to skip the datetime to string
+    conversion that the default converter does.
+    """
+
+    def toWidgetValue(self, value):
+        """Converts from field value to widget.
+        Overridden because we're being passed a string, but the parent class
+        expects a datetime object.
+
+        :param value: Field value.
+        :type value: str (misteriously not a datetime)
+
+        :returns: Datetime in format `Y-m-d H:M`
+        :rtype: string
+        """
+        return value

--- a/src/plonetheme/eeq/overrides.py
+++ b/src/plonetheme/eeq/overrides.py
@@ -38,7 +38,7 @@ class TileDatetimeWidgetConverter(DatetimeWidgetConverter):
         can use it: '2021-06-01T03:40:00' → '2021-06-30 09:00'.
 
         :param value: Field value.
-        :type value: str or None (misteriously not a datetime)
+        :type value: str or None (mysteriously not a datetime)
 
         :returns: Datetime in format `Y-m-d H:M`
         :rtype: string

--- a/src/plonetheme/eeq/overrides.py
+++ b/src/plonetheme/eeq/overrides.py
@@ -34,11 +34,13 @@ class TileDatetimeWidgetConverter(DatetimeWidgetConverter):
         """Converts from field value to widget.
         Overridden because we're being passed a string, but the parent class
         expects a datetime object.
+        The format is also changed so that the patterns library datetime widget
+        can use it: '2021-06-01T03:40:00' → '2021-06-30 09:00'.
 
         :param value: Field value.
-        :type value: str (misteriously not a datetime)
+        :type value: str or None (misteriously not a datetime)
 
         :returns: Datetime in format `Y-m-d H:M`
         :rtype: string
         """
-        return value
+        return value and value.replace("T", " ")[:16]

--- a/src/plonetheme/eeq/theme/less/tiles.less
+++ b/src/plonetheme/eeq/theme/less/tiles.less
@@ -23,8 +23,23 @@
   }
 }
 
+/* show in-active alert tiles on edit page */
+.template-edit {
+  .mosaic-tile-content {
+    .alert {
+      &.in-active {
+        display: inline-block;
+        background-color: #eee;
+      }
+    }
+  }
+}
+
 .mosaic-tile-content {
   .alert {
+    &.in-active {
+        display: none;
+    }
     .fa-bell {
         font-size: 3rem;
         margin: .5rem 1.5rem 1rem 0;

--- a/src/plonetheme/eeq/theme/less/tiles.less
+++ b/src/plonetheme/eeq/theme/less/tiles.less
@@ -30,6 +30,7 @@
       &.in-active {
         display: inline-block;
         background-color: #eee;
+        width: 100% !important;
       }
     }
   }


### PR DESCRIPTION
This is an attempt to add date range selection for the alert tile, 
if out of range, add a simple "in-active" class, and hide tile via css. 

The issue is that the Datetime widgets are returning dates as strings, which is strange (I would expect datetime or Zope datetime) but ok we can deal with it and process it to calculate if to display the tile or not.

However then attempting to re-edit a tile that has a datetime value set (ie. not blank), we get this:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 266, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.app.tiles.browser.edit, line 51, in update
  Module plone.app.tiles.browser.base, line 104, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 132, in update
  Module plone.app.tiles.browser.base, line 121, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 132, in update
  Module plone.app.z3cform.converters, line 51, in toWidgetValue
AttributeError: 'str' object has no attribute 'year'
```

 seems the Datetime widget doesn't recognize its own format?

![Untitled-1](https://user-images.githubusercontent.com/883619/123674174-989f9080-d841-11eb-9378-bfd3bbfa0968.jpg)
