### PR TITLE
Make sure mosaic tiles on the same row have the same height

### DIFF
--- a/src/plonetheme/eeq/browser/overrides/jazkarta.tesserae.templates.summary.pt
+++ b/src/plonetheme/eeq/browser/overrides/jazkarta.tesserae.templates.summary.pt
@@ -10,7 +10,7 @@
     <metal:macro define-macro="summary"
                  tal:define="url content/absolute_url|nothing;
                              title content/Title|nothing;
-                             image_url python: url + '/@@images/image';
+                             image_url python: url + '/@@images/image/psu_tile';
                              toLocalizedTime nocall:context/@@plone/toLocalizedTime;">
     <div class="card" tal:condition="nocall:content">
         <div tal:condition="image_url"


### PR DESCRIPTION
See #28

I was not able to solve the same-height issue using only CSS.
This PR adds the `jquery.matchHeight.js` plugin and invokes it to make sure that all mosaic tiles on the same row have the same height.


With this change instead of this:
![Screenshot from 2022-01-11 16-41-31](https://user-images.githubusercontent.com/396425/148974270-0d3c3d6b-46e7-4c83-a242-13eece3dc9bb.png)
it shows this:
![Screenshot from 2022-01-11 16-42-36](https://user-images.githubusercontent.com/396425/148974308-8ffe7fef-0397-4170-8366-342aadf3c33c.png)
