### PR TITLE
Use hero image from parent office/folder or default to `assets/default_hero`

### DIFF
--- a/src/plonetheme/eeq/browser/hero.py
+++ b/src/plonetheme/eeq/browser/hero.py
@@ -1,0 +1,32 @@
+from plone.app.layout.viewlets import common as base
+from plone import api
+
+
+class HeroImage(base.ViewletBase):
+    def render(self):
+        context = self.get_folder_or_office_context()
+        if context is None:
+            portal = api.portal.get()
+            try:
+                url = portal.assets.default_hero.absolute_url() + "/@@images/image/psu_hero"
+            except AttributeError:
+                url = portal.absolute_url() + "/++theme++psu-educational-equity/images/hero-home.jpg"
+        else:
+            url = context.absolute_url() + "/@@images/image/psu_hero"
+        return f"""
+        <span id="office-leadimage">
+            <img alt="" id="hero-image" class="w-100 d-none d-md-block" src="{url}" />
+        </span>
+        """
+
+    def get_folder_or_office_context(self):
+        """Walk up the acquisition chain until we find
+        an office or folder that has a lead image specified.
+        """
+        context = self.context
+        while hasattr(context, "portal_type"):
+            if context.portal_type in ["plonetheme.eeq.office", "Folder"]:
+                if hasattr(context, "image") and context.image:
+                    return context
+            context = context.aq_parent
+        return None

--- a/src/plonetheme/eeq/browser/office.py
+++ b/src/plonetheme/eeq/browser/office.py
@@ -3,10 +3,11 @@ from plone.app.layout.viewlets import common as base
 
 class OfficeLinks(base.ViewletBase):
     """Viewlet to render links in the office navigation bar.
+    Also renders the office title and the hero banner.
     """
 
     def render(self):
-        office = self.office_context()
+        self.office = office = self.office_context()
         if office is None:
             return ""
 

--- a/src/plonetheme/eeq/browser/overrides/jazkarta.tesserae.templates.summary.pt
+++ b/src/plonetheme/eeq/browser/overrides/jazkarta.tesserae.templates.summary.pt
@@ -6,10 +6,12 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="plone">
-  <body tal:define="content nocall:view/content; type content/portal_type|nothing">
+  <body tal:define="content nocall:view/content;
+                    type content/portal_type|nothing;
+                    url content/absolute_url|nothing;"
+        tal:condition="url">
     <metal:macro define-macro="summary"
-                 tal:define="url content/absolute_url|nothing;
-                             title content/Title|nothing;
+                 tal:define="title content/Title|nothing;
                              image_scale python:type == 'plonetheme.eeq.office' and 'psu_office' or 'psu_tile';
                              image_url python: url + '/@@images/image/' + image_scale;
                              toLocalizedTime nocall:context/@@plone/toLocalizedTime;">

--- a/src/plonetheme/eeq/browser/templates/office-links.pt
+++ b/src/plonetheme/eeq/browser/templates/office-links.pt
@@ -14,3 +14,6 @@
         </li>
     </ul>
 </div>
+<span id="office-title">
+    <a href="${view/office/absolute_url}">${view/office/title}</a>
+</span>

--- a/src/plonetheme/eeq/theme/rules.xml
+++ b/src/plonetheme/eeq/theme/rules.xml
@@ -50,6 +50,9 @@
   <replace css:theme-children="#navbar-office-left" css:content-children="#office-navbar-left" />
   <replace css:theme-children="#navbar-office-right" css:content-children="#office-navbar-right" />
 
+  <!-- Office header -->
+  <replace css:theme-children=".office-name-wrapper .office-name" css:content-children="#office-title" />
+
   <!-- full-width breadcrumb -->
   <replace css:theme-children="nav#portal-breadcrumbs">
     <ol class="breadcrumb">


### PR DESCRIPTION
See #11 and #12 

The hero image is looked up in these locations:

* the first parent office or folder that has a lead image specified
* the image content type located at `/assets/default_hero`
* the image included in the theme